### PR TITLE
Add a Windows native CI Build Job

### DIFF
--- a/.github/workflows/build_glide3_voodoo45_gcc.yml
+++ b/.github/workflows/build_glide3_voodoo45_gcc.yml
@@ -1,4 +1,4 @@
-name: Build Glide3x for Voodoo3/4/5 Library
+name: Build Glide3x for Voodoo3/4/5 Library (GCC)
 
 on:
   push:

--- a/.github/workflows/build_glide3_voodoo45_gcc.yml
+++ b/.github/workflows/build_glide3_voodoo45_gcc.yml
@@ -7,22 +7,18 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  build_gcc:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
     defaults:
       run:
         working-directory: "glide3x/h5"
     container:
       image: 'danaozhong/3dfx_glide_dev_env_linux_x64:latest'
-      
-    env:
-      # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-      BUILD_TYPE: Debug
-  
+    
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -62,34 +58,34 @@ jobs:
       run: |
         mkdir bin_x64
         cd bin_x64
-        cmake ..
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build .
         
     - name: Generate Glide3x Dynamic Link Library (Linux, x32)
       run: |
         mkdir bin_x32
         cd bin_x32
-        cmake -DBUILD_32BIT=ON ..
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_32BIT=ON ..
         cmake --build .
         
-    - name: Generate Glide3x Dynamic Link Library (Windows, x64)
+    - name: Generate Glide3x Dynamic Link Library (Windows, GCC cross compile), x64)
       run: |
         mkdir bin_win_x64
         cd bin_win_x64
-        cmake -DCMAKE_TOOLCHAIN_FILE=mingw-w64-x86_64.cmake -DCMAKE_INSTALL_PREFIX=../prefix-64 ..
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_TOOLCHAIN_FILE=mingw-w64-x86_64.cmake -DCMAKE_INSTALL_PREFIX=../prefix-64 ..
         cmake --build .
 
-    - name: Generate Glide3x Dynamic Link Library (Windows, x32)
+    - name: Generate Glide3x Dynamic Link Library (Windows, GCC cross compile), x32)
       run: |
         mkdir bin_win_x32
         cd bin_win_x32
-        cmake -DCMAKE_TOOLCHAIN_FILE=mingw-w64-x86_32.cmake -DCMAKE_INSTALL_PREFIX=../prefix-64 ..
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_TOOLCHAIN_FILE=mingw-w64-x86_32.cmake -DCMAKE_INSTALL_PREFIX=../prefix-64 ..
         cmake --build .
         
     - name: Upload Built Glide3x Library
       uses: actions/upload-artifact@v2
       with:
-        name: glide3x Voodo345
+        name: gcc_glide3x_voodoo345_${{ matrix.build_type }}
         path: |
             glide3x/h5/bin_x32/*.so
             glide3x/h5/bin_x64/*.so

--- a/.github/workflows/build_glide3_voodoo45_msvc.yml
+++ b/.github/workflows/build_glide3_voodoo45_msvc.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         mkdir fxgasm_tool/bin
         cd fxgasm_tool/bin
-        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake -DCMAKE_GENERATOR_PLATFORM=Win32 ..
         cmake --build .
         
     - name: Generate Header Files
@@ -44,7 +44,7 @@ jobs:
       run: |
         mkdir fxbldno_tool/bin
         cd fxbldno_tool/bin
-        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake -DCMAKE_GENERATOR_PLATFORM=Win32 ..
         cmake --build .
         
     - name: Generate Build Number Header Files
@@ -56,14 +56,14 @@ jobs:
       run: |
         mkdir bin_win_x64
         cd bin_win_x64
-        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake -DCMAKE_GENERATOR_PLATFORM=Win32 ..
         cmake --build . --config ${{ matrix.build_type }}
 
     - name: Generate Glide3x Dynamic Link Library (Windows, x32)
       run: |
         mkdir bin_win_x32
         cd bin_win_x32
-        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake -DCMAKE_GENERATOR_PLATFORM=Win32 ..
         cmake --build . --config ${{ matrix.build_type }}
         
     - name: Upload Built Glide3x Library

--- a/.github/workflows/build_glide3_voodoo45_msvc.yml
+++ b/.github/workflows/build_glide3_voodoo45_msvc.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Generate Header Files
       working-directory: "glide3x/h5/glide3/src/"
       run: |
-        ./fxgasm_tool/bin/fxgasm.exe -inline > fxinline.h
-        ./fxgasm_tool/bin/fxgasm.exe -hex > fxgasm.h
+        ./fxgasm_tool/bin/Debug/fxgasm.exe -inline > fxinline.h
+        ./fxgasm_tool/bin/Debug/fxgasm.exe -hex > fxgasm.h
 
     - name: Generate Fx Build Number Tool
       working-directory: "glide3x/h5/glide3/src/"
@@ -50,7 +50,7 @@ jobs:
     - name: Generate Build Number Header Files
       working-directory: "glide3x/h5/glide3/src/"
       run: |
-        ./fxbldno_tool/bin/fxbldno  > fxbldno.h
+        ./fxbldno_tool/bin/Debug/fxbldno.exe  > fxbldno.h
 
     - name: Generate Glide3x Dynamic Link Library (Windows, x64)
       run: |

--- a/.github/workflows/build_glide3_voodoo45_msvc.yml
+++ b/.github/workflows/build_glide3_voodoo45_msvc.yml
@@ -18,6 +18,7 @@ jobs:
         working-directory: "glide3x/h5"
 
     steps:
+    - uses: ilammy/setup-nasm@v1
     - name: Checkout
       uses: actions/checkout@v2
 

--- a/.github/workflows/build_glide3_voodoo45_msvc.yml
+++ b/.github/workflows/build_glide3_voodoo45_msvc.yml
@@ -1,0 +1,76 @@
+name: Build Glide3x for Voodoo3/4/5 Library (MSVC)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_msvc:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+    defaults:
+      run:
+        working-directory: "glide3x/h5"
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Create Artifact Directory
+      run: |
+        mkdir ${{ github.workspace }}/artifacts
+        
+    - name: Generate FXGasm Tool
+      working-directory: "glide3x/h5/glide3/src/"
+      run: |
+        mkdir fxgasm_tool/bin
+        cd fxgasm_tool/bin
+        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake --build .
+        
+    - name: Generate Header Files
+      working-directory: "glide3x/h5/glide3/src/"
+      run: |
+        ./fxgasm_tool/bin/fxgasm.exe -inline > fxinline.h
+        ./fxgasm_tool/bin/fxgasm.exe -hex > fxgasm.h
+
+    - name: Generate Fx Build Number Tool
+      working-directory: "glide3x/h5/glide3/src/"
+      run: |
+        mkdir fxbldno_tool/bin
+        cd fxbldno_tool/bin
+        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake --build .
+        
+    - name: Generate Build Number Header Files
+      working-directory: "glide3x/h5/glide3/src/"
+      run: |
+        ./fxbldno_tool/bin/fxbldno  > fxbldno.h
+
+    - name: Generate Glide3x Dynamic Link Library (Windows, x64)
+      run: |
+        mkdir bin_win_x64
+        cd bin_win_x64
+        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Generate Glide3x Dynamic Link Library (Windows, x32)
+      run: |
+        mkdir bin_win_x32
+        cd bin_win_x32
+        cmake -DCMAKE_GENERATOR_PLATFORM=x32 ..
+        cmake --build . --config ${{ matrix.build_type }}
+        
+    - name: Upload Built Glide3x Library
+      uses: actions/upload-artifact@v2
+      with:
+        name: msvc_glide3x_voodoo345_${{ matrix.build_type }}
+        path: |
+            glide3x/h5/bin_win_x64/*.dll
+            glide3x/h5/bin_win_x32/*.dll
+        

--- a/.github/workflows/build_glide3_voodoo45_msvc.yml
+++ b/.github/workflows/build_glide3_voodoo45_msvc.yml
@@ -72,6 +72,7 @@ jobs:
       with:
         name: msvc_glide3x_voodoo345_${{ matrix.build_type }}
         path: |
-            glide3x/h5/bin_win_x64/*.dll
-            glide3x/h5/bin_win_x32/*.dll
-        
+            glide3x/h5/bin_win_x32/Release/*.dll
+            glide3x/h5/bin_win_x32/Debug/*.dll
+            glide3x/h5/bin_win_x64/Release/*.dll
+            glide3x/h5/bin_win_x64/Debug/*.dll

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This is the source code to 3Dfx Glide for Voodoo graphics accelerators. It's for
 
 The source is licensed under 3DFX GLIDE Source Code General Public License.
 
+## CI Status
+![win-glide3-vodoo345-msvc-build](https://github.com/Danaozhong/3dfx-Glide-API/actions/workflows/build_glide3_voodoo45_msvc.yml/badge.svg)
+![win-glide3-vodoo345-gcc-build](https://github.com/Danaozhong/3dfx-Glide-API/actions/workflows/build_glide3_voodoo45_gcc.yml/badge.svg)
+![win-glide3-vodoo2-gcc-build](https://github.com/Danaozhong/3dfx-Glide-API/actions/workflows/build_glide3_voodoo2.yml/badge.svg)
+![win-glide2-vodoo2-gcc-build](https://github.com/Danaozhong/3dfx-Glide-API/actions/workflows/build_glide2_voodoo3.yml/badge.svg)
+![win-glide2-vodoo2-gcc-build](https://github.com/Danaozhong/3dfx-Glide-API/actions/workflows/build_glide2_voodoo2.yml/badge.svg)
+![linux-glide2-vodoo2-gcc-build](https://github.com/Danaozhong/3dfx-Glide-API/actions/workflows/build_glide2_linux.yml/badge.svg)
+
 ## Motivation
 
 Although 3dfx disappeared from the marked in 2000, there is still a large community of enthusiasts that enjoy using 3dfx video cards up to this day.
@@ -13,7 +21,7 @@ The Glide API is, similar to OpenGL/Direct3D, a 3D API. It is used by many old-s
 
 This project is a port of the Open-Source Linux Glide libraries, and supports cross-platform builds for Linux and Windows, both x86 and x64.
 
-The toolchain is ported to CMake to simplify cross-platform builds, and get rid of a large set of hard to use makefiles.
+The toolchain is ported to CMake to simplify cross-platform builds, and get rid of a large set of hard-to-use makefiles.
 
 ## How to Build?
 The libraries are tested under Linux, using the mingw-w64 cross-platform compiler. Visual Studio builds might also work, but are currently not tested in the Github Action CI environment.
@@ -29,7 +37,7 @@ The simplest way to build the libraries is to use the provided docker container,
 
 ### Build Example (Windows, Visual Studio)
 
-Let's build the Glide3 DLL for Voodo3/4/5 using Visual Studio.
+Let's build the Glide3 DLL for Voodoo3/4/5 using Visual Studio.
 
 Go to the Glide3 directory:
 ```ps1

--- a/glide3x/README
+++ b/glide3x/README
@@ -1,6 +1,9 @@
 Glide3x (dec-2004):
 ~~~~~~~~~~~~~~~~~~~
 
+2024-05-06 Daonaozhong - this document is outdated, the build has been ported to CMake.
+
+
 sst1:	Voodoo Graphics XOR Voodoo Rush
 	Maintainers: Daniel Borca
 

--- a/glide3x/h5/CMakeLists.txt
+++ b/glide3x/h5/CMakeLists.txt
@@ -220,18 +220,19 @@ target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
     #-DGL_MMX
     #-DGL_SSE
     #-DGL_SSE2
-    -DGL_X86
-
-    # Do not use the ASM routines, but the C triangle setup routines instead
-    -DGLIDE_USE_C_TRISETUP
+    #-DGL_X86
 )
 
 
 if (${BUILD_32BIT})
-
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
+        -DGL_X86
+    )
 else()
     target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
         -DGLIDE_BUILD_64BIT
+        # Do not use the ASM routines, but the C triangle setup routines instead
+        -DGLIDE_USE_C_TRISETUP
     )
 
 endif()


### PR DESCRIPTION
- minor improvements to the GCC builds.
- add GCC-build matrix (debug/release).
- add CI job to build on Windows natively.